### PR TITLE
Add release-please and brew tap

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,16 @@
+name: homebrew
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  bump-formula:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dawidd6/action-homebrew-bump-formula@v4
+        with:
+          token: ${{ secrets.HOMEBREW_TOKEN }}
+          formula: toolbelt
+          tap: stianfro/homebrew-toolbelt
+          tag: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,15 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          release-type: go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [created]
 
 jobs:
   build:
@@ -15,15 +14,25 @@ jobs:
           go-version-file: go.mod
       - name: Build binaries
         run: |
-          GOOS=linux GOARCH=amd64 go build -o toolbelt-linux-amd64
-          GOOS=darwin GOARCH=amd64 go build -o toolbelt-darwin-amd64
-          GOOS=windows GOARCH=amd64 go build -o toolbelt-windows-amd64.exe
+          mkdir -p dist
+          GOOS=linux GOARCH=amd64 go build -o dist/toolbelt-linux-amd64
+          GOOS=linux GOARCH=arm64 go build -o dist/toolbelt-linux-arm64
+          GOOS=darwin GOARCH=amd64 go build -o dist/toolbelt-darwin-amd64
+          GOOS=darwin GOARCH=arm64 go build -o dist/toolbelt-darwin-arm64
+          tar -C dist -czf toolbelt-linux-amd64.tar.gz toolbelt-linux-amd64
+          tar -C dist -czf toolbelt-linux-arm64.tar.gz toolbelt-linux-arm64
+          tar -C dist -czf toolbelt-darwin-amd64.tar.gz toolbelt-darwin-amd64
+          tar -C dist -czf toolbelt-darwin-arm64.tar.gz toolbelt-darwin-arm64
+          GOOS=windows GOARCH=amd64 go build -o dist/toolbelt-windows-amd64.exe
+          zip -j toolbelt-windows-amd64.zip dist/toolbelt-windows-amd64.exe
       - name: Upload release assets
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            toolbelt-linux-amd64
-            toolbelt-darwin-amd64
-            toolbelt-windows-amd64.exe
+            toolbelt-linux-amd64.tar.gz
+            toolbelt-linux-arm64.tar.gz
+            toolbelt-darwin-amd64.tar.gz
+            toolbelt-darwin-arm64.tar.gz
+            toolbelt-windows-amd64.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,0 +1,4 @@
+{
+  "release-type": "go",
+  "package-name": "toolbelt"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/Formula/toolbelt.rb
+++ b/Formula/toolbelt.rb
@@ -1,0 +1,17 @@
+class Toolbelt < Formula
+  desc "Toolbelt consolidates scripts into a CLI tool"
+  homepage "https://github.com/stianfro/toolbelt"
+  url "https://github.com/stianfro/toolbelt/archive/refs/tags/v0.0.0.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args
+  end
+
+  test do
+    assert_match "toolbelt", shell_output("#{bin}/toolbelt --help")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ Run the CLI with:
 toolbelt
 ```
 
+### Homebrew
+
+You can also install the CLI using Homebrew:
+
+```bash
+brew tap stianfro/toolbelt
+brew install toolbelt
+```
+
 ## Commands
 
 ### organize
@@ -23,4 +32,5 @@ toolbelt
 Moves receipts from the `unorganized` directory into the monthly folder
 matching the date prefix on each file.
 
-Releases are published when tagging the repository. Prebuilt binaries for common platforms are available on the release page.
+Releases are created automatically from conventional commits using release-please.
+Prebuilt binaries for common platforms are available on the release page.


### PR DESCRIPTION
## Summary
- automate releases using release-please
- compress binaries in the release workflow
- add workflow to update a Homebrew tap
- provide a Homebrew formula
- document brew installation instructions

## Testing
- `go vet ./...`
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_68679563e5288322bb63f2279406cf8a