### PR TITLE
Fix release workflow triggers

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -3,14 +3,24 @@ name: homebrew
 on:
   release:
     types: [published]
+  workflow_run:
+    workflows: ["release-please"]
+    types:
+      - completed
 
 jobs:
   bump-formula:
     runs-on: ubuntu-latest
     steps:
+      - name: Determine release tag
+        id: get_tag
+        if: github.event_name == 'workflow_run'
+        run: echo "tag=$(gh release view --json tagName -q .tagName)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
       - uses: dawidd6/action-homebrew-bump-formula@v4
         with:
           token: ${{ secrets.HOMEBREW_TOKEN }}
           formula: toolbelt
           tap: stianfro/homebrew-toolbelt
-          tag: ${{ github.event.release.tag_name }}
+          tag: ${{ github.event.release.tag_name || steps.get_tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,16 +2,28 @@ name: Release
 
 on:
   release:
-    types: [created]
+    types: [published]
+  workflow_run:
+    workflows: ["release-please"]
+    types:
+      - completed
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - name: Determine release tag
+        id: get_tag
+        if: github.event_name == 'workflow_run'
+        run: echo "tag=$(gh release view --json tagName -q .tagName)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Build binaries
         run: |
           mkdir -p dist
@@ -34,5 +46,6 @@ jobs:
             toolbelt-darwin-amd64.tar.gz
             toolbelt-darwin-arm64.tar.gz
             toolbelt-windows-amd64.zip
+          tag_name: ${{ github.event.release.tag_name || steps.get_tag.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- trigger Release and Homebrew workflows when release-please publishes a release
- compute release tag when triggered by `workflow_run`

## Testing
- `go build ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6867a320cfac83229fa58cc4ffae3caf